### PR TITLE
Add link to APIKeyMiddleware library

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Simply press <kbd>Command</kbd> + <kbd>F</kbd> to search for a keyword. If you�
 - ![v3](img/vapor-3.png) [VaporExt](https://github.com/vapor-community/vapor-ext) – A collection of Swift extensions for wide range of Vapor data types and classes.
 - ![v3](img/vapor-3.png) [WKHTMLTOPDF](https://github.com/MihaelIsaev/wkhtmltopdf) – Build PDF files from Leaf templates or web pages through the `wkhtmltopdf` CLI tool.
 - ![v3](img/vapor-3.png) [XMLCoding](https://github.com/LiveUI/XMLCoding) – XML encoder and decoder.
+- ![v4](img/vapor-4.png) [APIKeyMiddleware](https://github.com/ptrkstr/APIKeyMiddleware) – Middleware for adding api-key header support.
 
 ## Tools
 


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-vapor 🙇 -->

<!-- Please make SURE you create your pull request against the `master` branch! -->
<!-- The filtered versions for specific versions of Vapor are created automatically! -->

<!-- Please fill out the short form below -->

<!-- To mark the checkboxes as completed, put an `x` inside the squared brackets, like so: [x] -->

- **Project Name**: APIKeyMiddleware
- **Project URL**: https://github.com/ptrkstr/APIKeyMiddleware
- **Project Description**:  Swift package for adding API Key requirement to vapor backends. 
- **Why it should be added to `awesome-vapor`**: Simplifies adding additional security to vapor backends.
- [ ] Project has at least 15 stars (if it’s a GitHub project) - 🥺
- [ ] Project supports at least Vapor 3 - supports Vapor 4
- [x] Project supports at least Swift 5
- [x] I used correctly sized dash and ended the entry with a full stop 🤓
